### PR TITLE
Correctly destroying the colorpicker instance

### DIFF
--- a/autoform-bootstrap-colorpicker.js
+++ b/autoform-bootstrap-colorpicker.js
@@ -17,13 +17,14 @@ Template.afBootstrapColorpicker.helpers({
   }
 });
 
-Template.afBootstrapColorpicker.rendered = function () {
+Template.afBootstrapColorpicker.onRendered(function afBootstrapColorpickerOnRendered() {
   var $input = this.$('.input-group');
   // initiate the colorpicker
-  $input.colorpicker();
-};
+  this.colorpicker = $input.colorpicker().data('colorpicker');
+});
 
-Template.afBootstrapColorpicker.destroyed = function () {
-  var $input = this.$('.input-group');
-  $input.colorpicker('destroy');
-};
+Template.afBootstrapColorpicker.onDestroyed(function afBootstrapColorpickerOnDestroyed() {
+  // Reference to the picker instance is lost when removed from dom.
+  // Destroying the instance directly.
+  this.colorpicker.destroy();
+});

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
   api.use('templating@1.0.0');
-  api.use('aldeed:autoform@5.0.0');
+  api.use('aldeed:autoform@5.0.0', 'client');
   api.addFiles([
     'lib/bootstrap-colorpicker/dist/js/bootstrap-colorpicker.js',
     'lib/bootstrap-colorpicker/dist/css/bootstrap-colorpicker.css',


### PR DESCRIPTION
This fixes the issue when `$input.colorpicker('destroy');` throws `Error: TypeError: Cannot read property 'destroy' of undefined` as soon as the AutoForm is destroyed.
